### PR TITLE
Bisq 0.5.2 running in docker (linux host only)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,56 @@
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+*.java text
+*.xml text
+*.xsl text
+*.csv text
+*.conf text
+*.properties text
+*.jsp text
+*.css text
+*.scss text
+*.svg text
+*.js text
+*.html text
+*.episode text
+*.xsd text
+*.dtd text
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.gif binary
+*.zip binary
+*.jar binary
+*.doc binary
+*.docx binary
+*.dot binary
+*.xls binary
+*.otf binary
+*.eot binary
+*.ttf binary
+*.ttf binary
+*.woff binary
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+### Eclipse
+.project
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.classpath
+.project
+.settings/
+.loadpath
+.externalToolBuilders/
+*.launch
+
+### IDEA
+.idea/*
+*.ipr
+*.iws
+*/*.iml
+
+### Maven
+target/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+###
+#
+# Bisq Dockerfile installation:
+#
+# build:
+#
+# docker build -t bisq-0.5.2 .
+#
+# run:
+# You can run it from an X11 capable linux client like this:
+# xhost +
+# docker run -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY bisq-0.5.2
+#
+###
+
+FROM maven:3.5-jdk-8
+
+# maintainer details
+MAINTAINER Cédric Walter "cedric.walter@gmail.com"
+
+# add openjfx
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        openjfx \
+        unzip \
+    && apt-get clean \
+    && rm -f /var/lib/apt/lists/*_dists_*
+
+# save repository
+COPY settings-docker.xml /usr/share/maven/ref/
+
+# clone and install bitcoinj_version
+WORKDIR /local/git
+RUN git clone -b bisq_0.14.4.1 https://github.com/bitsquare/bitcoinj.git
+WORKDIR /local/git/bitcoinj
+RUN mvn clean install -DskipTests -gs /usr/share/maven/ref/settings-docker.xml
+
+WORKDIR /local/git
+RUN git clone https://github.com/bitsquare/libdohj.git
+WORKDIR /local/git/libdohj
+RUN mvn clean install -DskipTests -gs /usr/share/maven/ref/settings-docker.xml
+
+WORKDIR /local/git
+RUN git clone https://github.com/bitsquare/btcd-cli4j.git
+WORKDIR /local/git/btcd-cli4j
+RUN mvn clean install -DskipTests -gs /usr/share/maven/ref/settings-docker.xml
+
+WORKDIR /local/git
+RUN git clone https://github.com/bitsquare/bitsquare.git
+WORKDIR /local/git/bitsquare
+RUN mvn clean install -DskipTests -gs /usr/share/maven/ref/settings-docker.xml
+WORKDIR /local/git/
+
+VOLUME /home/root/.local/share/Bitsquare 
+CMD java -jar /local/git/bitsquare/gui/target/shaded.jar

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Bisq-Docker
 Docker build for Bisq/Bitssquare
 
-```git clone https://github.com/cedricwalter/Bisq-Docker.git && cd Bisq-Docker```
+```git clone https://github.com/bitsquare/Bisq-Docker.git && cd Bisq-Docker```
 
-# Build
+# Build image
 ```sudo docker build -t bisq-0.5.2 .```
 
-# Run
+# Run container
 You may want to mount the bisq data directory on your host for easier upgrades
 ```sudo docker run -v $PWD/data:/root/.local/share/bisq -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY bisq-0.5.2```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Bisq-Docker
+Docker build for Bisq/Bitssquare
+
+```git clone https://github.com/cedricwalter/Bisq-Docker.git && cd Bisq-Docker```
+
+# Build
+```sudo docker build -t bisq-0.5.2 .```
+
+# Run
+You may want to mount the bisq data directory on your host for easier upgrades
+```sudo docker run -v $PWD/data:/root/.local/share/bisq -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY bisq-0.5.2```
+
+# Bisq data directory
+Read also CAREFULLY https://github.com/bitsquare/bitsquare/wiki/Switching-to-a-new-data-directory

--- a/settings-docker.xml
+++ b/settings-docker.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>


### PR DESCRIPTION
Tested on Ubuntu 16.10 with docker 1.12.6

Next steps:
* make image support headless node/seed node/api
* solve UI issue on windows, OSx (x11)
* best practices for docker security review (ongoing)
* push to docker hub for broader user consumption
* cleanup bitsquare\package\linux folder in bitsquare
